### PR TITLE
Using assertSame to make assert equals restricted

### DIFF
--- a/tests/RatingSystemTest.php
+++ b/tests/RatingSystemTest.php
@@ -17,7 +17,7 @@ final class RatingSystemTest extends TestCase
      */
     public function testRatingAfterDraw(ContestantInterface $contestant, ContestantInterface $opponent, int $expectedNewRating): void
     {
-        $this->assertEquals(
+        $this->assertSame(
             $expectedNewRating,
             (new RatingSystem())->calculateRatingAfterDraw($contestant, $opponent)
         );
@@ -89,7 +89,7 @@ final class RatingSystemTest extends TestCase
      */
     public function testRatingAfterLoss(ContestantInterface $contestant, ContestantInterface $opponent, int $expectedNewRating): void
     {
-        $this->assertEquals(
+        $this->assertSame(
             $expectedNewRating,
             (new RatingSystem())->calculateRatingAfterLoss($contestant, $opponent)
         );
@@ -161,7 +161,7 @@ final class RatingSystemTest extends TestCase
      */
     public function testRatingAfterWin(ContestantInterface $contestant, ContestantInterface $opponent, int $expectedNewRating): void
     {
-        $this->assertEquals(
+        $this->assertSame(
             $expectedNewRating,
             (new RatingSystem())->calculateRatingAfterWin($contestant, $opponent)
         );


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace then `assertEquals` and it can make assert equals restricted.